### PR TITLE
:green_hearth:: Fix GitHub Actions workflows shellcheck issues

### DIFF
--- a/.github/workflows/push.release.yaml
+++ b/.github/workflows/push.release.yaml
@@ -40,7 +40,7 @@ jobs:
         run: |
           # Get current version
           CURRENT_VERSION=$(node -p "require('./package.json').version")
-          echo "Current version: $CURRENT_VERSION"
+          echo "Current version: ${CURRENT_VERSION}"
 
           # Get previous version from the previous commit
           git checkout HEAD~1
@@ -50,17 +50,17 @@ jobs:
             PREVIOUS_VERSION="none"
           fi
           git checkout -
-          echo "Previous version: $PREVIOUS_VERSION"
+          echo "Previous version: ${PREVIOUS_VERSION}"
 
           # Check if version has changed
-          if [ "$CURRENT_VERSION" != "$PREVIOUS_VERSION" ]; then
-            echo "Version has changed from $PREVIOUS_VERSION to $CURRENT_VERSION"
-            echo "should_release=true" >> $GITHUB_OUTPUT
-            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+          if [ "${CURRENT_VERSION}" != "${PREVIOUS_VERSION}" ]; then
+            echo "Version has changed from ${PREVIOUS_VERSION} to ${CURRENT_VERSION}"
+            echo "should_release=true" >> "${GITHUB_OUTPUT}"
+            echo "version=${CURRENT_VERSION}" >> "${GITHUB_OUTPUT}"
           else
-            echo "Version has not changed ($CURRENT_VERSION)"
-            echo "should_release=false" >> $GITHUB_OUTPUT
-            echo "version=$CURRENT_VERSION" >> $GITHUB_OUTPUT
+            echo "Version has not changed (${CURRENT_VERSION})"
+            echo "should_release=false" >> "${GITHUB_OUTPUT}"
+            echo "version=${CURRENT_VERSION}" >> "${GITHUB_OUTPUT}"
           fi
 
   build:
@@ -89,13 +89,13 @@ jobs:
       - name: 📄 Create checksums
         run: |
           SHA256_FILE="extension_checksums.txt"
-          sha256sum ./dist/extension.tar > ${SHA256_FILE}
+          sha256sum ./dist/extension.tar > "${SHA256_FILE}"
           echo "Created checksum file: ${SHA256_FILE}"
-          cat ${SHA256_FILE}
+          cat "${SHA256_FILE}"
 
       - name: 🚀 Create GitHub Release
         run: |
           VERSION="v${{ needs.check-version.outputs.version }}"
-          gh release create ${VERSION} --draft --generate-notes ./dist/extension.tar ./extension_checksums.txt
+          gh release create "${VERSION}" --draft --generate-notes ./dist/extension.tar ./extension_checksums.txt
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/workflow_dispatch.version-bump.yaml
+++ b/.github/workflows/workflow_dispatch.version-bump.yaml
@@ -49,16 +49,16 @@ jobs:
         id: auto-bump
         run: |
           npm version ${{ steps.nyx.outputs.version }} --no-git-tag-version
-          echo "version=${{ steps.nyx.outputs.version }}" >> $GITHUB_OUTPUT
-          echo "bump_type=${{ steps.nyx.outputs.bump }}" >> $GITHUB_OUTPUT
+          echo "version=${{ steps.nyx.outputs.version }}" >> "${GITHUB_OUTPUT}"
+          echo "bump_type=${{ steps.nyx.outputs.bump }}" >> "${GITHUB_OUTPUT}"
 
       - name: 📝 Manual version bump
         if: github.event.inputs.version_type != 'auto'
         id: manual-bump
         run: |
           npm version ${{ github.event.inputs.version_type }} --no-git-tag-version
-          echo "version=$(node -p "require('./package.json').version")" >> $GITHUB_OUTPUT
-          echo "bump_type=${{ github.event.inputs.version_type }}" >> $GITHUB_OUTPUT
+          echo "version=$(node -p "require('./package.json').version")" >> "${GITHUB_OUTPUT}"
+          echo "bump_type=${{ github.event.inputs.version_type }}" >> "${GITHUB_OUTPUT}"
 
       - name: 🔏 Create signed commit
         # Run if manual bump or if auto and new version was found
@@ -75,17 +75,17 @@ jobs:
 
           # Create a new commit using GitHub API (GraphQL) to get signed commit
           gh api graphql \
-            -f query='mutation($repo:String!,$branch:String!,$message:String!,$path:String!,$content:Base64String!,$oid:GitObjectID!){
+            -f query="mutation(\$repo:String!,\$branch:String!,\$message:String!,\$path:String!,\$content:Base64String!,\$oid:GitObjectID!){
               createCommitOnBranch(input:{
-                branch:{repositoryNameWithOwner:$repo,branchName:$branch},
-                message:{headline:$message},
-                fileChanges:{additions:[{path:$path,contents:$content}]},
-                expectedHeadOid:$oid
+                branch:{repositoryNameWithOwner:\$repo,branchName:\$branch},
+                message:{headline:\$message},
+                fileChanges:{additions:[{path:\$path,contents:\$content}]},
+                expectedHeadOid:\$oid
               }){commit{url}}
-            }' \
+            }" \
             -f repo="${{ github.repository }}" \
             -f branch="main" \
-            -f message="🚀: bump $BUMP_TYPE version to $VERSION" \
+            -f message="🚀: bump ${BUMP_TYPE} version to ${VERSION}" \
             -f path="package.json" \
             -f content="$(base64 -w 0 package.json)" \
             -f oid="$(git rev-parse HEAD)"


### PR DESCRIPTION
This pull request focuses on improving the robustness and consistency of environment variable usage in GitHub Actions workflows by wrapping all variable references in braces and quoting them. This ensures better handling of special characters and prevents potential issues with unquoted variables. The changes span across two workflow files: `.github/workflows/push.release.yaml` and `.github/workflows/workflow_dispatch.version-bump.yaml`.

### Updates to `.github/workflows/push.release.yaml`:

* Wrapped environment variable references like `CURRENT_VERSION`, `PREVIOUS_VERSION`, and `GITHUB_OUTPUT` in braces and added quotes to ensure proper handling and prevent unintended behavior. [[1]](diffhunk://#diff-c1a612d12a55f3ae205e1aca41463f404be244c99ed6b4b9cf094bca0d49c1c2L43-R43) [[2]](diffhunk://#diff-c1a612d12a55f3ae205e1aca41463f404be244c99ed6b4b9cf094bca0d49c1c2L53-R63)
* Updated checksum creation and GitHub release steps to quote file paths and variable references, improving reliability.

### Updates to `.github/workflows/workflow_dispatch.version-bump.yaml`:

* Quoted `GITHUB_OUTPUT` and other variable references in steps related to version bumping (both auto and manual) for enhanced safety and consistency.
* Adjusted commit message formatting by quoting and wrapping variables like `BUMP_TYPE` and `VERSION` to maintain consistency.